### PR TITLE
[#173508066] WIP - Clean up data after integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 coverage
 .vscode
 src/generated
+.env

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "nodemon dist/index.js",
     "build": "tsc",
-    "test": "jest",
+    "test": "dotenv -e .env jest",
     "lint": "tslint --project ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "nodemon dist/index.js",
     "build": "tsc",
-    "test": "dotenv -e .env jest",
+    "test": "dotenv -e .env jest --runInBand",
     "lint": "tslint --project ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "tslint --project ."
   },
   "devDependencies": {
+    "@types/documentdb": "^1.10.6",
     "@types/express": "^4.17.6",
     "@types/jest": "^26.0.0",
     "@types/morgan": "^1.9.0",
@@ -32,6 +33,7 @@
   "dependencies": {
     "@types/express-xml-bodyparser": "^0.3.1",
     "body-parser": "^1.19.0",
+    "documentdb": "^1.15.3",
     "express": "^4.17.1",
     "express-xml-bodyparser": "^0.3.0",
     "fp-ts": "1.17.4",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import waitForExpect from "wait-for-expect";
 import { makeFiscalCode } from "../fixtures/fiscalcode";
 import { initExpressServer } from "../server";
 import { createTestingSession } from "../utils/test-utils/cleanup";
+import { BonusDocumentDbClient } from "../utils/test-utils/io-bonus-db";
 
 // tslint:disable-next-line: no-object-mutation
 waitForExpect.defaults.timeout = 30000;
@@ -21,7 +22,14 @@ const API_URL = "http://localhost:7071/api/v1";
 
 // tslint:disable-next-line: no-let
 let server: http.Server;
-const testingSession = createTestingSession();
+// tslint:disable-next-line: no-let
+const testingSession = createTestingSession(
+  new BonusDocumentDbClient({
+    cosmosDbName: process.env.COSMOSDB_BONUS_DATABASE_NAME || "",
+    cosmosDbUri: process.env.COSMOSDB_BONUS_URI || "",
+    masterKey: process.env.COSMOSDB_BONUS_KEY
+  })
+);
 
 beforeAll(async () => {
   server = await initExpressServer(requestMock, responseMock);
@@ -30,7 +38,7 @@ beforeAll(async () => {
 afterAll(async () => {
   server.close();
   const cleanedData = await testingSession.cleanData().catch(err => {
-    console.error('cleanup general failure', err);
+    console.error("cleanup general failure", err);
     return [];
   });
   cleanedData.forEach(([log, result]) => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,12 +1,21 @@
 // tslint:disable: no-identical-functions
 
 import * as http from "http";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
 import fetch from "node-fetch";
 import waitForExpect from "wait-for-expect";
-import { makeFiscalCode } from "../fixtures/fiscalcode";
+import {
+  getFamilyMembersForFiscalCode,
+  makeFiscalCode
+} from "../fixtures/fiscalcode";
 import { initExpressServer } from "../server";
-import { createTestingSession } from "../utils/test-utils/cleanup";
+import {
+  createTestingSession,
+  ITestingSession,
+  printCleanReport
+} from "../utils/test-utils/cleanup";
 import { BonusDocumentDbClient } from "../utils/test-utils/io-bonus-db";
+import { generateFamilyUID } from "../utils/test-utils/misc";
 
 // tslint:disable-next-line: no-object-mutation
 waitForExpect.defaults.timeout = 30000;
@@ -18,48 +27,51 @@ jest.setTimeout(40000);
 const responseMock = jest.fn();
 const requestMock = jest.fn();
 
+const sleep = (ms: number) => new Promise(ok => setTimeout(ok, ms));
+
 const API_URL = "http://localhost:7071/api/v1";
+
+const db = new BonusDocumentDbClient({
+  cosmosDbName: process.env.COSMOSDB_BONUS_DATABASE_NAME || "",
+  cosmosDbUri: process.env.COSMOSDB_BONUS_URI || "",
+  masterKey: process.env.COSMOSDB_BONUS_KEY
+});
 
 // tslint:disable-next-line: no-let
 let server: http.Server;
-// tslint:disable-next-line: no-let
-const testingSession = createTestingSession(
-  new BonusDocumentDbClient({
-    cosmosDbName: process.env.COSMOSDB_BONUS_DATABASE_NAME || "",
-    cosmosDbUri: process.env.COSMOSDB_BONUS_URI || "",
-    masterKey: process.env.COSMOSDB_BONUS_KEY
-  })
-);
-
 beforeAll(async () => {
   server = await initExpressServer(requestMock, responseMock);
 });
 
 afterAll(async () => {
+  await sleep(5000);
   server.close();
-  const cleanedData = await testingSession.cleanData().catch(err => {
-    console.error("cleanup general failure", err);
-    return [];
-  });
-  cleanedData.forEach(([log, result]) => {
-    if (result) {
-      console.log(`cleanup success ${log}`);
-    } else {
-      console.error(`cleanup failure ${log}`);
-    }
-  });
 });
-afterEach(() => jest.resetAllMocks());
+beforeEach(() => jest.resetAllMocks());
 
-describe("init", () => {
-  it("should be sottosoglia", async () => {
-    const fiscalCode = makeFiscalCode({
+describe("Scenario: DSU is not eligible", () => {
+  // tslint:disable-next-line: no-let one-variable-per-declaration
+  let fiscalCode: FiscalCode, testingSession: ITestingSession;
+
+  beforeAll(() => {
+    testingSession = createTestingSession(db);
+    fiscalCode = makeFiscalCode({
       adeResponse: "A",
       adeTimeout: 0,
-      inpsResponse: "A",
+      inpsResponse: "D",
       inpsTimeout: 0
     });
+  });
+
+  afterAll(async () => {
+    await testingSession.cleanData().then(printCleanReport);
+  });
+
+  it("should not be sottosoglia", async () => {
     testingSession.registerFiscalCode(fiscalCode);
+    testingSession.registerFamilyUID(
+      generateFamilyUID(getFamilyMembersForFiscalCode(fiscalCode))
+    );
 
     const res = await fetch(
       `${API_URL}/bonus/vacanze/eligibility/${fiscalCode}`,
@@ -68,7 +80,57 @@ describe("init", () => {
       }
     );
     expect(res.status).toEqual(201);
-    expect(await res.json()).toMatchObject({ id: fiscalCode });
+    expect(await res.json()).toMatchObject({
+      id: fiscalCode
+    });
+    await waitForExpect(() => {
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      expect(responseMock).toHaveBeenCalledWith(
+        expect.stringContaining('SottoSoglia="NO"')
+      );
+    });
+    await waitForExpect(() => {
+      expect(requestMock).toHaveBeenCalledTimes(2);
+      const req = requestMock.mock.calls[1][0];
+      expect(JSON.stringify(req.body)).toContain("supera la soglia");
+    });
+    expect(true).toBeTruthy();
+  });
+});
+
+describe("Scenario: DSU is eligible and ADE will approve", () => {
+  // tslint:disable-next-line: no-let one-variable-per-declaration
+  let fiscalCode: FiscalCode, testingSession: ITestingSession;
+
+  beforeAll(() => {
+    testingSession = createTestingSession(db);
+    fiscalCode = makeFiscalCode({
+      adeResponse: "A",
+      adeTimeout: 0,
+      inpsResponse: "A",
+      inpsTimeout: 0
+    });
+  });
+
+  afterAll(async () => {
+    await testingSession.cleanData().then(printCleanReport);
+  });
+  it("should be sottosoglia", async () => {
+    testingSession.registerFiscalCode(fiscalCode);
+    testingSession.registerFamilyUID(
+      generateFamilyUID(getFamilyMembersForFiscalCode(fiscalCode))
+    );
+
+    const res = await fetch(
+      `${API_URL}/bonus/vacanze/eligibility/${fiscalCode}`,
+      {
+        method: "POST"
+      }
+    );
+    expect(res.status).toEqual(201);
+    expect(await res.json()).toMatchObject({
+      id: fiscalCode
+    });
     await waitForExpect(() => {
       expect(requestMock).toHaveBeenCalledTimes(1);
       expect(responseMock).toHaveBeenCalledWith(
@@ -85,46 +147,7 @@ describe("init", () => {
     expect(true).toBeTruthy();
   });
 
-  it("should not be sottosoglia", async () => {
-    const fiscalCode = makeFiscalCode({
-      adeResponse: "A",
-      adeTimeout: 0,
-      inpsResponse: "D",
-      inpsTimeout: 0
-    });
-    testingSession.registerFiscalCode(fiscalCode);
-
-    const res = await fetch(
-      `${API_URL}/bonus/vacanze/eligibility/${fiscalCode}`,
-      {
-        method: "POST"
-      }
-    );
-    expect(res.status).toEqual(201);
-    expect(await res.json()).toMatchObject({ id: fiscalCode });
-    await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(1);
-      expect(responseMock).toHaveBeenCalledWith(
-        expect.stringContaining('SottoSoglia="NO"')
-      );
-    });
-    await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(2);
-      const req = requestMock.mock.calls[1][0];
-      expect(JSON.stringify(req.body)).toContain("supera la soglia");
-    });
-    expect(true).toBeTruthy();
-  });
-
   it("should succeed bonus activation", async () => {
-    const fiscalCode = makeFiscalCode({
-      adeResponse: "A",
-      adeTimeout: 0,
-      inpsResponse: "A",
-      inpsTimeout: 0
-    });
-    testingSession.registerFiscalCode(fiscalCode);
-
     const res = await fetch(
       `${API_URL}/bonus/vacanze/activations/${fiscalCode}`,
       {

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,10 @@ import { Millisecond } from "italia-ts-commons/lib/units";
 import * as morgan from "morgan";
 import { CONFIG } from "./config";
 import { ADE_RESPONSES } from "./fixtures/ade";
-import { parseFiscalCode } from "./fixtures/fiscalcode";
+import {
+  getFamilyMembersForFiscalCode,
+  parseFiscalCode
+} from "./fixtures/fiscalcode";
 import { INPS_RESPONSES } from "./fixtures/inps";
 
 export async function newExpressApp(
@@ -37,11 +40,9 @@ export async function newExpressApp(
 
     const options = parseFiscalCode(fiscalCode);
 
-    const [status, payload] = INPS_RESPONSES[options.inpsResponse]([
-      fiscalCode,
-      fiscalCode.replace("YYY", "TTT"),
-      fiscalCode.replace("YYY", "PPP")
-    ]);
+    const [status, payload] = INPS_RESPONSES[options.inpsResponse](
+      getFamilyMembersForFiscalCode(fiscalCode)
+    );
 
     await delayTask(
       (options.inpsTimeout * 1000) as Millisecond,

--- a/src/fixtures/fiscalcode.ts
+++ b/src/fixtures/fiscalcode.ts
@@ -26,7 +26,7 @@ export const makeFiscalCode = ({
   inpsTimeout
 }: FiscalCodeParams): FiscalCode => {
   return FiscalCode.decode(
-    `${adeResponse}${inpsResponse}XYYY${zeroPad(adeTimeout, 2)}R13Y5${zeroPad(
+    `${adeResponse}${inpsResponse}XYYY${zeroPad(adeTimeout, 2)}R16F9${zeroPad(
       inpsTimeout,
       2
     )}K`
@@ -44,4 +44,14 @@ export const parseFiscalCode = (fiscalCode: FiscalCode): FiscalCodeParams => {
   } as FiscalCodeParams).getOrElseL(errs => {
     throw new Error(`unable to parse fiscal code ${readableReport(errs)}`);
   });
+};
+
+export const getFamilyMembersForFiscalCode = (
+  fiscalCode: FiscalCode
+): ReadonlyArray<FiscalCode> => {
+  return [
+    fiscalCode,
+    fiscalCode.replace("YYY", "TTT") as FiscalCode,
+    fiscalCode.replace("YYY", "PPP") as FiscalCode
+  ];
 };

--- a/src/fixtures/inps.ts
+++ b/src/fixtures/inps.ts
@@ -24,7 +24,6 @@ export const EligibilityCheckSuccessEligible = (
                   ProtocolloDSU="INPS-ISEE-2020-00000032P-00" 
                   DataPresentazioneDSU="2020-01-23" PresenzaDifformita="NO">
                   ${familyMembers.map(memberStr)}
-  <Componente CodiceFiscale="BAAAAA00A00A000B" Cognome="Matteo" Nome="Boschi"/>
 </DatiIndicatore></ConsultazioneSogliaIndicatoreResult>
 </ConsultazioneSogliaIndicatoreResponse>
 </s:Body>

--- a/src/utils/test-utils/__tests__/cleanup.test.ts
+++ b/src/utils/test-utils/__tests__/cleanup.test.ts
@@ -1,9 +1,17 @@
 import { createTestingSession } from "../cleanup";
+import { BonusDocumentDbClient } from "../io-bonus-db";
 
 const dryRun = true;
+const mockDbClient = ({
+  deleteBonusActivation: jest.fn(),
+  deleteBonusProcessing: jest.fn(),
+  deleteEligibilityCheck: jest.fn(),
+  deleteUserBonus: jest.fn()
+} as unknown) as BonusDocumentDbClient;
+
 describe("createTestingSession", () => {
   it("should clean nothing", async () => {
-    const testingSession = createTestingSession();
+    const testingSession = createTestingSession(mockDbClient);
 
     const result = await testingSession.cleanData(dryRun);
 
@@ -13,7 +21,7 @@ describe("createTestingSession", () => {
   it("should perform cleanup on provided fiscal code", async () => {
     const fiscalCode = "AAABBB80A01C123D";
 
-    const testingSession = createTestingSession();
+    const testingSession = createTestingSession(mockDbClient);
     testingSession.registerFiscalCode(fiscalCode);
 
     const result = await testingSession.cleanData(dryRun);
@@ -29,7 +37,7 @@ describe("createTestingSession", () => {
   it("should perform cleanup on provided bonus code", async () => {
     const bonus = "XXXXX1234YY";
 
-    const testingSession = createTestingSession();
+    const testingSession = createTestingSession(mockDbClient);
     testingSession.registerBonus(bonus);
 
     const result = await testingSession.cleanData(dryRun);

--- a/src/utils/test-utils/__tests__/cleanup.test.ts
+++ b/src/utils/test-utils/__tests__/cleanup.test.ts
@@ -1,0 +1,44 @@
+import { createTestingSession } from "../cleanup";
+
+const dryRun = true;
+describe("createTestingSession", () => {
+  it("should clean nothing", async () => {
+    const testingSession = createTestingSession();
+
+    const result = await testingSession.cleanData(dryRun);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should perform cleanup on provided fiscal code", async () => {
+    const fiscalCode = "AAABBB80A01C123D";
+
+    const testingSession = createTestingSession();
+    testingSession.registerFiscalCode(fiscalCode);
+
+    const result = await testingSession.cleanData(dryRun);
+
+    expect(result.length).toBeGreaterThan(0);
+
+    result.forEach(([log, out]) => {
+      expect(log).toEqual(expect.stringContaining(fiscalCode));
+      expect(out).toBe(true);
+    });
+  });
+
+  it("should perform cleanup on provided bonus code", async () => {
+    const bonus = "XXXXX1234YY";
+
+    const testingSession = createTestingSession();
+    testingSession.registerBonus(bonus);
+
+    const result = await testingSession.cleanData(dryRun);
+
+    expect(result.length).toBeGreaterThan(0);
+
+    result.forEach(([log, out]) => {
+      expect(log).toEqual(expect.stringContaining(bonus));
+      expect(out).toBe(true);
+    });
+  });
+});

--- a/src/utils/test-utils/cleanup.ts
+++ b/src/utils/test-utils/cleanup.ts
@@ -1,0 +1,93 @@
+import {
+  deleteBonusActivation,
+  deleteBonusProcessing,
+  deleteEligibilityCheck,
+  deleteUserBonus
+} from "./io-bonus-db";
+
+const cleanUpDb = async ({
+  fiscalCodes,
+  bonuses,
+  dryRun
+}: {
+  fiscalCodes: readonly string[];
+  bonuses: readonly string[];
+  dryRun: boolean;
+}): Promise<ReadonlyArray<readonly [string, boolean]>> => {
+  const executeOrDryRun = async (
+    fn: () => Promise<void>,
+    label: string
+  ): Promise<readonly [string, boolean]> => {
+    if (dryRun) {
+      return [label, true];
+    }
+    return fn()
+      .then(_ => true)
+      .catch(_ => false)
+      .then(result => [label, result]);
+  };
+
+  const operations: ReadonlyArray<Promise<readonly [string, boolean]>> = [
+    // eligibility checks
+    ...fiscalCodes.map(fiscalCode =>
+      executeOrDryRun(
+        () => deleteEligibilityCheck(fiscalCode),
+        `DELETE EligibilityCheck for ${fiscalCode}`
+      )
+    ),
+    // bonus activation
+    ...bonuses.map(bonus =>
+      executeOrDryRun(
+        () => deleteBonusActivation(bonus),
+        `DELETE BonusActivation for ${bonus}`
+      )
+    ),
+    // user bonus
+    ...bonuses.map(bonus =>
+      executeOrDryRun(
+        () => deleteUserBonus(bonus),
+        `DELETE UserBonus for ${bonus}`
+      )
+    ),
+    // bonus processing
+    ...bonuses.map(bonus =>
+      executeOrDryRun(
+        () => deleteBonusProcessing(bonus),
+        `DELETE BonusProcessing for ${bonus}`
+      )
+    )
+    // TODO: bonus lease
+  ];
+
+  return Promise.all(operations);
+};
+
+const TestingSession = () => {
+  const data = {
+    bonuses: new Set<string>(),
+    fiscalCodes: new Set<string>()
+  };
+
+  return {
+    async cleanData(
+      dryRun = false
+    ): Promise<ReadonlyArray<readonly [string, boolean]>> {
+      const result = await cleanUpDb({
+        bonuses: [...data.bonuses],
+        dryRun,
+        fiscalCodes: [...data.fiscalCodes]
+      });
+      data.bonuses.clear();
+      data.fiscalCodes.clear();
+      return result;
+    },
+    registerFiscalCode(fiscalCode: string): void {
+      data.fiscalCodes.add(fiscalCode);
+    },
+    registerBonus(bonus: string): void {
+      data.bonuses.add(bonus);
+    }
+  };
+};
+
+export const createTestingSession = () => TestingSession();

--- a/src/utils/test-utils/io-bonus-db.ts
+++ b/src/utils/test-utils/io-bonus-db.ts
@@ -1,0 +1,73 @@
+// tslint:disable: no-identical-functions
+
+import * as DocumentDb from "documentdb";
+
+// TODO: handle env variable properly
+const cosmosDbUri = process.env.COSMOSDB_BONUS_URI || "https://cosmosuri/";
+const cosmosDbName = process.env.COSMOSDB_BONUS_DATABASE_NAME || "dbname";
+const masterKey = process.env.COSMOSDB_BONUS_KEY || "base64Key";
+
+const documentClient = new DocumentDb.DocumentClient(
+  cosmosDbUri,
+  {
+    masterKey
+  },
+  undefined,
+  "Strong"
+);
+
+const deleteDocument = (
+  documentUri: string,
+  partitionKey: string
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    documentClient.deleteDocument(documentUri, { partitionKey }, err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+export const deleteEligibilityCheck = (fiscalCode: string): Promise<void> =>
+  deleteDocument(
+    DocumentDb.UriFactory.createDocumentUri(
+      cosmosDbName,
+      "eligibility-checks",
+      fiscalCode
+    ),
+    fiscalCode
+  );
+
+export const deleteBonusActivation = (bonusId: string): Promise<void> =>
+  deleteDocument(
+    DocumentDb.UriFactory.createDocumentUri(
+      cosmosDbName,
+      "bonus-activations",
+      bonusId
+    ),
+    bonusId
+  );
+
+export const deleteUserBonus = async (bonusId: string): Promise<void> =>
+  deleteDocument(
+    DocumentDb.UriFactory.createDocumentUri(
+      cosmosDbName,
+      "user-bonuses",
+      bonusId
+    ),
+    bonusId
+  );
+
+export const deleteBonusProcessing = async (bonusId: string): Promise<void> =>
+  deleteDocument(
+    DocumentDb.UriFactory.createDocumentUri(
+      cosmosDbName,
+      "user-bonuses",
+      bonusId
+    ),
+    bonusId
+  );
+
+export const deleteBonusLease = async (bonusId: string): Promise<void> => {};

--- a/src/utils/test-utils/io-bonus-db.ts
+++ b/src/utils/test-utils/io-bonus-db.ts
@@ -44,6 +44,10 @@ export class BonusDocumentDbClient {
     return this.deleteDocument("bonus-processing", bonusId);
   }
 
+  public deleteBonusLease(familyUID: string): Promise<void> {
+    return this.deleteDocument("bonus-leases", familyUID);
+  }
+
   private deleteDocument(
     collectionName: string,
     documentId: string,

--- a/src/utils/test-utils/io-bonus-db.ts
+++ b/src/utils/test-utils/io-bonus-db.ts
@@ -56,7 +56,11 @@ export class BonusDocumentDbClient {
     );
     return new Promise((resolve, reject) => {
       this.documentClient.deleteDocument(documentUri, { partitionKey }, err => {
-        if (err) {
+        if (
+          err &&
+          // it's not an error if there's no record to eliminate
+          err.code !== 404
+        ) {
           reject(err);
         } else {
           resolve();

--- a/src/utils/test-utils/misc.ts
+++ b/src/utils/test-utils/misc.ts
@@ -1,0 +1,21 @@
+import * as crypto from "crypto";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+
+/**
+ * Replicate the behavior of https://github.com/pagopa/io-functions-bonus/blob/3f67ba697704530f336d0408c8665183333e3395/utils/hash.ts#L23
+ * @param familyMembers a set of family members as returned from bonus activation api
+ *
+ * @returns a string which is the FamilyUID as it would be calculate on io-functions-bonus
+ */
+export const generateFamilyUID = (
+  // tslint:disable-next-line: variable-name
+  family_members: ReadonlyArray<FiscalCode>
+): string => {
+  const plain = Array.from(family_members)
+    .sort((a, b) => a.localeCompare(b))
+    .join("");
+  return crypto
+    .createHash("sha256")
+    .update(plain)
+    .digest("hex");
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/documentdb@^1.10.6":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/@types/documentdb/-/documentdb-1.10.6.tgz#156c15d720e6871de06371c96d93c7b57ee1b627"
+  integrity sha512-OHYaRvBlJL2rl75MeSilgwOUmwtsr39pYQZYG6lmPI5MJveqFQHi9RiaKJ20z5cQT6uAwTR/BZLRCKP9F2bg/g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/express-serve-static-core@*":
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz#157c79c2d28b632d6418497c57c93185e392e444"
@@ -805,22 +812,25 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.25:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+binary-search-bounds@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz#5ff8616d6dd2ca5388bc85b2d6266e2b9da502dc"
+  integrity sha1-X/hhbW3SylOIvIWy1iZuK52lAtw=
+
 bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
-body-parser-xml@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/body-parser-xml/-/body-parser-xml-2.0.0.tgz#2ebdaf266aa6c9bdd1d41ddd63db83763fe3a744"
-  integrity sha512-F0mOPykzMFsj7YX0D/bNmqG5h/n0TKH5Jfl3NX9nwxh3BnxwT6PDCmf7rP9cVOyOJpUAPhtgv+zYVRuoHVA3LA==
-  dependencies:
-    xml2js "^0.4.16"
 
 body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
@@ -1417,6 +1427,20 @@ doctrine@0.7.2:
   dependencies:
     esutils "^1.1.6"
     isarray "0.0.1"
+
+documentdb@^1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/documentdb/-/documentdb-1.15.3.tgz#ce83a248515667054d45009ff94c4a1e5f72067b"
+  integrity sha512-V+B0D1arcWVT3uv/Nms2aNNeJBgndysDcXfyOFgz2dlMCmY8cWMFXFuo+6T4A8PjLL2pI9QSoo4CwXQBREFcnA==
+  dependencies:
+    big-integer "^1.6.25"
+    binary-search-bounds "2.0.3"
+    debug "^4.1.0"
+    int64-buffer "^0.1.9"
+    priorityqueuejs "1.0.0"
+    semaphore "1.0.5"
+    tunnel "0.0.5"
+    underscore "1.8.3"
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -2247,6 +2271,11 @@ ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+int64-buffer@^0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
+  integrity sha1-J3siiofZWtd30HwTgyAiQGpHNCM=
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -3984,6 +4013,11 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+priorityqueuejs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz#2ee4f23c2560913e08c07ce5ccdd6de3df2c5af8"
+  integrity sha1-LuTyPCVgkT4IwHzlzN1t498sWvg=
+
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -4365,6 +4399,11 @@ sax@>=0.6, sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+semaphore@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.0.5.tgz#b492576e66af193db95d65e25ec53f5f19798d60"
+  integrity sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA=
 
 semver-diff@^3.1.1:
   version "3.1.1"
@@ -5103,6 +5142,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.5.tgz#d1532254749ed36620fcd1010865495a1fa9d0ae"
+  integrity sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -5166,6 +5210,11 @@ undefsafe@^2.0.2:
   integrity sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==
   dependencies:
     debug "^2.2.0"
+
+underscore@1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
 underscore@~1.7.0:
   version "1.7.0"
@@ -5472,7 +5521,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@^0.4.11, xml2js@^0.4.16:
+xml2js@^0.4.11:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==


### PR DESCRIPTION
This introduces a cleanup script that wipes out data from database when tests end.

### Implementation
A `TestingSession` is started at the beginning of tests and then the suite is run as usual. Each time we find references during the execution, we annotate it (example: `registerFiscalCode(fiscalCode)` will annotate `fiscalCode` in a local variable).
Once the suite is terminated, a session is disposed by cleaning up data: a pre-configured set of queries are executed using the references collected during the suite execution.

### TODOs
* ~Handle db client creation safely, using env variables. Graceful fail the test suite if a wrong config is passed.~
* ~Handle query errors: so far we just print out a failure log.~ **Won't do it**
* ~Understand how to deal with `bonus-leases` collection: it is indeed the only collection which is created during the execution, but we don't have the reference (`familyUID`). The only viable solution so far is to infer such reference by creating a familyUID in the test suite itself.~ **we replicated the familyUID creation mechanism**
