### PR TITLE
[#173609242] Refactor Integration tests

### DIFF
--- a/src/__mocks__/mocks.ts
+++ b/src/__mocks__/mocks.ts
@@ -1,0 +1,11 @@
+export const processInpsRequest = jest.fn();
+export const processInpsResponse = jest.fn();
+
+export const processAdeRequest = jest.fn();
+export const processAdeResponse = jest.fn();
+
+export const processServiceGetProfileRequest = jest.fn();
+export const processServiceGetProfileResponse = jest.fn();
+
+export const processServiceSendMessageRequest = jest.fn();
+export const processServiceSendMessageResponse = jest.fn();

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -213,7 +213,7 @@ describe("Scenario: DSU is eligible and ADE will approve", () => {
       expect(processServiceSendMessageRequest).toHaveBeenCalledTimes(
         familyMembers.length
       );
-      // each family memeber gets her message
+      // each family member gets her message
       familyMembers.forEach(memberFiscalCode => {
         // the test passes if at least one of the sent messages
         // has been sent to the currente family member

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -5,6 +5,16 @@ import { FiscalCode } from "italia-ts-commons/lib/strings";
 import fetch from "node-fetch";
 import waitForExpect from "wait-for-expect";
 import {
+  processAdeRequest,
+  processAdeResponse,
+  processInpsRequest,
+  processInpsResponse,
+  processServiceGetProfileRequest,
+  processServiceGetProfileResponse,
+  processServiceSendMessageRequest,
+  processServiceSendMessageResponse
+} from "../__mocks__/mocks";
+import {
   getFamilyMembersForFiscalCode,
   makeFiscalCode
 } from "../fixtures/fiscalcode";
@@ -24,9 +34,6 @@ waitForExpect.defaults.interval = 50;
 
 jest.setTimeout(40000);
 
-const responseMock = jest.fn();
-const requestMock = jest.fn();
-
 const sleep = (ms: number) => new Promise(ok => setTimeout(ok, ms));
 
 const API_URL = "http://localhost:7071/api/v1";
@@ -40,7 +47,16 @@ const db = new BonusDocumentDbClient({
 // tslint:disable-next-line: no-let
 let server: http.Server;
 beforeAll(async () => {
-  server = await initExpressServer(requestMock, responseMock);
+  server = await initExpressServer({
+    processAdeRequest,
+    processAdeResponse,
+    processInpsRequest,
+    processInpsResponse,
+    processServiceGetProfileRequest,
+    processServiceGetProfileResponse,
+    processServiceSendMessageRequest,
+    processServiceSendMessageResponse
+  });
 });
 
 afterAll(async () => {
@@ -52,6 +68,8 @@ beforeEach(() => jest.resetAllMocks());
 describe("Scenario: DSU is not eligible", () => {
   // tslint:disable-next-line: no-let one-variable-per-declaration
   let fiscalCode: FiscalCode, testingSession: ITestingSession;
+  // tslint:disable-next-line: no-let
+  let familyMembers: ReturnType<typeof getFamilyMembersForFiscalCode>;
 
   beforeAll(() => {
     testingSession = createTestingSession(db);
@@ -61,6 +79,7 @@ describe("Scenario: DSU is not eligible", () => {
       inpsResponse: "D",
       inpsTimeout: 0
     });
+    familyMembers = getFamilyMembersForFiscalCode(fiscalCode);
   });
 
   afterAll(async () => {
@@ -69,9 +88,7 @@ describe("Scenario: DSU is not eligible", () => {
 
   it("should not be sottosoglia", async () => {
     testingSession.registerFiscalCode(fiscalCode);
-    testingSession.registerFamilyUID(
-      generateFamilyUID(getFamilyMembersForFiscalCode(fiscalCode))
-    );
+    testingSession.registerFamilyUID(generateFamilyUID(familyMembers));
 
     const res = await fetch(
       `${API_URL}/bonus/vacanze/eligibility/${fiscalCode}`,
@@ -84,23 +101,37 @@ describe("Scenario: DSU is not eligible", () => {
       id: fiscalCode
     });
     await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(1);
-      expect(responseMock).toHaveBeenCalledWith(
+      expect(processInpsRequest).toHaveBeenCalledTimes(1);
+      expect(processInpsResponse).toHaveBeenCalledWith(
         expect.stringContaining('SottoSoglia="NO"')
       );
     });
     await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(2);
-      const req = requestMock.mock.calls[1][0];
-      expect(JSON.stringify(req.body)).toContain("supera la soglia");
+      expect(processServiceSendMessageRequest).toHaveBeenCalledTimes(1);
+      const {
+        body: {
+          content: { subject, markdown }
+        },
+        path
+      } = processServiceSendMessageRequest.mock.calls[0][0];
+
+      // sent to the correct user
+      expect(path).toContain(fiscalCode);
+      // sent the correct message
+      expect(markdown).toContain("supera la soglia");
+      expect(subject).toContain("completato le verifiche");
+      // message sent
+      const { statusCode } = processServiceSendMessageResponse.mock.calls[0][0];
+      expect(statusCode).toBe(200);
     });
-    expect(true).toBeTruthy();
   });
 });
 
 describe("Scenario: DSU is eligible and ADE will approve", () => {
   // tslint:disable-next-line: no-let one-variable-per-declaration
   let fiscalCode: FiscalCode, testingSession: ITestingSession;
+  // tslint:disable-next-line: no-let
+  let familyMembers: ReturnType<typeof getFamilyMembersForFiscalCode>;
 
   beforeAll(() => {
     testingSession = createTestingSession(db);
@@ -110,6 +141,7 @@ describe("Scenario: DSU is eligible and ADE will approve", () => {
       inpsResponse: "A",
       inpsTimeout: 0
     });
+    familyMembers = getFamilyMembersForFiscalCode(fiscalCode);
   });
 
   afterAll(async () => {
@@ -117,9 +149,7 @@ describe("Scenario: DSU is eligible and ADE will approve", () => {
   });
   it("should be sottosoglia", async () => {
     testingSession.registerFiscalCode(fiscalCode);
-    testingSession.registerFamilyUID(
-      generateFamilyUID(getFamilyMembersForFiscalCode(fiscalCode))
-    );
+    testingSession.registerFamilyUID(generateFamilyUID(familyMembers));
 
     const res = await fetch(
       `${API_URL}/bonus/vacanze/eligibility/${fiscalCode}`,
@@ -132,22 +162,34 @@ describe("Scenario: DSU is eligible and ADE will approve", () => {
       id: fiscalCode
     });
     await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(1);
-      expect(responseMock).toHaveBeenCalledWith(
+      expect(processInpsRequest).toHaveBeenCalledTimes(1);
+      expect(processInpsResponse).toHaveBeenCalledWith(
         expect.stringContaining('SottoSoglia="SI"')
       );
     });
-    await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(2);
-      const req = requestMock.mock.calls[1][0];
-      expect(JSON.stringify(req.body)).toContain(
-        "il tuo nucleo familiare ha diritto al Bonus Vacanze"
-      );
+
+    await waitForExpect(async () => {
+      expect(processServiceSendMessageRequest).toHaveBeenCalledTimes(1);
+      const {
+        body: {
+          content: { subject, markdown }
+        },
+        path
+      } = processServiceSendMessageRequest.mock.calls[0][0];
+
+      // sent to the correct user
+      expect(path).toContain(fiscalCode);
+      // sent the correct message
+      expect(markdown).toContain("il tuo nucleo familiare ha diritto");
+      expect(subject).toContain("completato le verifiche");
+      // message sent
+      const { statusCode } = processServiceSendMessageResponse.mock.calls[0][0];
+      expect(statusCode).toBe(200);
     });
-    expect(true).toBeTruthy();
   });
 
   it("should succeed bonus activation", async () => {
+    await sleep(10000);
     const res = await fetch(
       `${API_URL}/bonus/vacanze/activations/${fiscalCode}`,
       {
@@ -163,16 +205,23 @@ describe("Scenario: DSU is eligible and ADE will approve", () => {
     testingSession.registerBonus(createdBonusActivation.id);
 
     await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(1);
-      expect(responseMock).toHaveBeenCalledWith(
-        expect.stringContaining("foobar")
-      );
+      expect(processAdeRequest).toHaveBeenCalledTimes(1);
+      expect(processAdeResponse).toHaveBeenCalledTimes(1);
     });
     await waitForExpect(() => {
-      expect(requestMock).toHaveBeenCalledTimes(2);
-      const req = requestMock.mock.calls[1][0];
-      expect(JSON.stringify(req.body)).toContain("foobar");
+      // one message per family member
+      expect(processServiceSendMessageRequest).toHaveBeenCalledTimes(
+        familyMembers.length
+      );
+      // each family memeber gets her message
+      familyMembers.forEach(memberFiscalCode => {
+        // the test passes if at least one of the sent messages
+        // has been sent to the currente family member
+        const allMessagePaths = processServiceSendMessageRequest.mock.calls
+          .map(([{ path }]) => path)
+          .join("|");
+        expect(allMessagePaths).toContain(memberFiscalCode);
+      });
     });
-    expect(true).toBeTruthy();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { constVoid } from "fp-ts/lib/function";
 import { initExpressServer } from "./server";
 
-// tslint:disable-next-line: no-any no-console
-initExpressServer(constVoid as any, constVoid as any).catch(console.error);
+// tslint:disable-next-line: no-console
+initExpressServer().catch(console.error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,27 @@
+// tslint:disable: no-any
+
+import { constVoid } from "fp-ts/lib/function";
 import * as http from "http";
 import * as App from "./app";
 import { CONFIG } from "./config";
 import { logger } from "./utils/logger";
 
+const voidProcessors: App.IMockServerProcessors = {
+  processAdeRequest: constVoid as any,
+  processAdeResponse: constVoid as any,
+  processInpsRequest: constVoid as any,
+  processInpsResponse: constVoid as any,
+  processServiceGetProfileRequest: constVoid as any,
+  processServiceGetProfileResponse: constVoid as any,
+  processServiceSendMessageRequest: constVoid as any,
+  processServiceSendMessageResponse: constVoid as any
+};
+
 export const initExpressServer = (
-  requestMock: jest.Mock,
-  reasponseMock: jest.Mock
+  processors: App.IMockServerProcessors = voidProcessors
 ): Promise<http.Server> =>
   // Create the Express Application
-  App.newExpressApp(CONFIG, requestMock, reasponseMock).then(app => {
+  App.newExpressApp(CONFIG, processors).then(app => {
     // Create a HTTP server from the new Express Application
     const server = http.createServer(app);
     server.listen(CONFIG.HTTP_PORT);


### PR DESCRIPTION
I refactored integration tests to improve readability and thus making easier to define new test scenarios. The following is a summary of introduced changes:

* [Use dedicated mocks](https://github.com/pagopa/io-bonus-inps-node-mock/compare/refactor?expand=1#diff-da4ff8448db4257666fc4d253664f72eL6) for tracing mock services' requests/responses
* Use a `describe` statement for each scenario, and include in each scenario a sequence of steps to reproduce the whole flow (steps are executed sequentially)
* Session is cleaned after each scenario (that is: data last for the duration of the whole scenario)
* Mocks are reset after each step
* Use `runInBand` to execute suites sequentially (however, we have a single suite so far) - it prevents data collision

